### PR TITLE
feat: add responseHook config to redis instrumentation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis/src/redis.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/redis.ts
@@ -29,6 +29,10 @@ import {
 import { RedisInstrumentationConfig } from './types';
 import { VERSION } from './version';
 
+const DEFAULT_CONFIG: RedisInstrumentationConfig = {
+  requireParentSpan: false
+};
+
 export class RedisInstrumentation extends InstrumentationBase<
   typeof redisTypes
 > {
@@ -36,6 +40,10 @@ export class RedisInstrumentation extends InstrumentationBase<
 
   constructor(protected _config: RedisInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-redis', VERSION, _config);
+  }
+
+  setConfig(config: RedisInstrumentationConfig = {}) {
+    this._config = Object.assign({}, DEFAULT_CONFIG, config);
   }
 
   protected init() {
@@ -100,8 +108,9 @@ export class RedisInstrumentation extends InstrumentationBase<
    */
   private _getPatchInternalSendCommand() {
     const tracer = this.tracer;
+    const config = this._config;
     return function internal_send_command(original: Function) {
-      return getTracedInternalSendCommand(tracer, original);
+      return getTracedInternalSendCommand(tracer, original, config);
     };
   }
 

--- a/plugins/node/opentelemetry-instrumentation-redis/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Span } from '@opentelemetry/api'
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type * as redisTypes from 'redis';
 
@@ -36,4 +37,43 @@ export interface RedisPluginClientTypes {
   address?: string;
 }
 
-export type RedisInstrumentationConfig = InstrumentationConfig;
+/**
+ * Function that can be used to serialize db.statement tag
+ * @param cmdName - The name of the command (eg. set, get, mset)
+ * @param cmdArgs - Array of arguments passed to the command
+ *
+ * @returns serialized string that will be used as the db.statement attribute.
+ */
+ export type DbStatementSerializer = (
+  cmdName: RedisCommand['command'],
+  cmdArgs: RedisCommand['args']
+) => string;
+
+/**
+ * Function that can be used to add custom attributes to span on response from redis server
+ * @param span - The span created for the redis command, on which attributes can be set
+ * @param cmdName - The name of the command (eg. set, get, mset)
+ * @param cmdArgs - Array of arguments passed to the command
+ * @param response - The response object which is returned to the user who called this command.
+ *  Can be used to set custom attributes on the span.
+ *  The type of the response varies depending on the specific command.
+ */
+export interface RedisResponseCustomAttributeFunction {
+  (
+    span: Span,
+    cmdName: RedisCommand['command'],
+    cmdArgs: RedisCommand['args'],
+    response: unknown
+  ): void;
+}
+
+export interface RedisInstrumentationConfig extends InstrumentationConfig {
+  /** Custom serializer function for the db.statement tag */
+  dbStatementSerializer?: DbStatementSerializer;
+
+  /** Function for adding custom attributes on db response */
+  responseHook?: RedisResponseCustomAttributeFunction;
+
+  /** Require parent to create redis span, default when unset is false */
+  requireParentSpan?: boolean;
+}

--- a/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
@@ -21,11 +21,14 @@ import {
   SpanKind,
   Span,
   SpanStatusCode,
+  getSpan,
+  diag,
 } from '@opentelemetry/api';
-import { RedisCommand, RedisPluginClientTypes } from './types';
+import { DbStatementSerializer, RedisCommand, RedisInstrumentationConfig, RedisPluginClientTypes } from './types';
 import { EventEmitter } from 'events';
 import { RedisInstrumentation } from './redis';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 
 const endSpan = (span: Span, err?: Error | null) => {
   if (err) {
@@ -64,9 +67,12 @@ export const getTracedCreateStreamTrace = (
   };
 };
 
+const defaultDbStatementSerializer: DbStatementSerializer = (cmdName, _cmdArgs) => cmdName
+
 export const getTracedInternalSendCommand = (
   tracer: Tracer,
-  original: Function
+  original: Function,
+  config?: RedisInstrumentationConfig
 ) => {
   return function internal_send_command_trace(
     this: RedisPluginClientTypes,
@@ -74,53 +80,70 @@ export const getTracedInternalSendCommand = (
   ) {
     // New versions of redis (2.4+) use a single options object
     // instead of named arguments
-    if (arguments.length === 1 && typeof cmd === 'object') {
-      const span = tracer.startSpan(
-        `${RedisInstrumentation.COMPONENT}-${cmd.command}`,
-        {
-          kind: SpanKind.CLIENT,
-          attributes: {
-            [SemanticAttributes.DB_SYSTEM]: RedisInstrumentation.COMPONENT,
-            [SemanticAttributes.DB_STATEMENT]: cmd.command,
-          },
-        }
-      );
-
-      // Set attributes for not explicitly typed RedisPluginClientTypes
-      if (this.options) {
-        span.setAttributes({
-          [SemanticAttributes.NET_PEER_NAME]: this.options.host,
-          [SemanticAttributes.NET_PEER_PORT]: this.options.port,
-        });
-      }
-      if (this.address) {
-        span.setAttribute(
-          SemanticAttributes.NET_PEER_IP,
-          `redis://${this.address}`
-        );
-      }
-
-      const originalCallback = arguments[0].callback;
-      if (originalCallback) {
-        (arguments[0] as RedisCommand).callback = function callback<T>(
-          this: unknown,
-          err: Error | null,
-          _reply: T
-        ) {
-          endSpan(span, err);
-          return originalCallback.apply(this, arguments);
-        };
-      }
-      try {
-        // Span will be ended in callback
-        return original.apply(this, arguments);
-      } catch (rethrow) {
-        endSpan(span, rethrow);
-        throw rethrow; // rethrow after ending span
-      }
+    if (arguments.length !== 1 || typeof cmd !== 'object') {
+      // We don't know how to trace this call, so don't start/stop a span
+      return original.apply(this, arguments);
     }
 
-    // We don't know how to trace this call, so don't start/stop a span
-    return original.apply(this, arguments);
+    const hasNoParentSpan = getSpan(context.active()) === undefined;
+    if (config?.requireParentSpan === true && hasNoParentSpan) {
+      return original.apply(this, arguments);
+    }
+
+    const dbStatementSerializer = config?.dbStatementSerializer || defaultDbStatementSerializer;
+    const span = tracer.startSpan(
+      `${RedisInstrumentation.COMPONENT}-${cmd.command}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          [SemanticAttributes.DB_SYSTEM]: RedisInstrumentation.COMPONENT,
+          [SemanticAttributes.DB_STATEMENT]: dbStatementSerializer(cmd.command, cmd.args),
+        },
+      }
+    );
+
+    // Set attributes for not explicitly typed RedisPluginClientTypes
+    if (this.options) {
+      span.setAttributes({
+        [SemanticAttributes.NET_PEER_NAME]: this.options.host,
+        [SemanticAttributes.NET_PEER_PORT]: this.options.port,
+      });
+    }
+    if (this.address) {
+      span.setAttribute(
+        SemanticAttributes.NET_PEER_IP,
+        `redis://${this.address}`
+      );
+    }
+
+    const originalCallback = arguments[0].callback;
+    if (originalCallback) {
+      (arguments[0] as RedisCommand).callback = function callback<T>(
+        this: unknown,
+        err: Error | null,
+        reply: T
+      ) {
+        if (config?.responseHook) {
+          const responseHook = config.responseHook;
+          safeExecuteInTheMiddle(() => {
+            responseHook(span, cmd.command, cmd.args, reply)
+          }, 
+          (err) => {
+            diag.error('Error executing responseHook', err)
+          },
+          true)
+        }
+
+        endSpan(span, err);
+        return originalCallback.apply(this, arguments);
+      };
+    }
+    try {
+      // Span will be ended in callback
+      return original.apply(this, arguments);
+    } catch (rethrow) {
+      endSpan(span, rethrow);
+      throw rethrow; // rethrow after ending span
+    }
   };
 };

--- a/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
@@ -21,6 +21,7 @@ import {
   SpanStatus,
   getSpan,
   setSpan,
+  Span,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
@@ -38,6 +39,7 @@ instrumentation.enable();
 instrumentation.disable();
 
 import * as redisTypes from 'redis';
+import { RedisResponseCustomAttributeFunction } from '../src/types';
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -128,23 +130,27 @@ describe('redis@2.x', () => {
     const REDIS_OPERATIONS: Array<{
       description: string;
       command: string;
+      args: string[];
       method: (cb: redisTypes.Callback<unknown>) => unknown;
     }> = [
       {
         description: 'insert',
         command: 'hset',
+        args: ['hash', 'random', 'random'],
         method: (cb: redisTypes.Callback<number>) =>
           client.hset('hash', 'random', 'random', cb),
       },
       {
         description: 'get',
         command: 'get',
+        args: ['test'],
         method: (cb: redisTypes.Callback<string | null>) =>
           client.get('test', cb),
       },
       {
         description: 'delete',
         command: 'del',
+        args: ['test'],
         method: (cb: redisTypes.Callback<number>) => client.del('test', cb),
       },
     ];
@@ -230,6 +236,126 @@ describe('redis@2.x', () => {
           });
         });
       });
+    });
+
+    describe('dbStatementSerializer config', () => {
+      const dbStatementSerializer = (cmdName: string, cmdArgs: string[]) => {
+        return Array.isArray(cmdArgs) && cmdArgs.length ? `${cmdName} ${cmdArgs.join(' ')}` : cmdName;
+      };
+
+      before(() => {
+        instrumentation.disable();
+        instrumentation.setConfig({ dbStatementSerializer })
+        instrumentation.enable();
+      });
+
+      REDIS_OPERATIONS.forEach(operation => {
+        it(`should properly execute the db statement serializer for operation ${operation.description}`, (done) => {
+          const span = tracer.startSpan('test span');
+          context.with(setSpan(context.active(), span), () => {
+            operation.method((err, _) => {
+              assert.ifError(err);
+              span.end();
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(endedSpans.length, 2);
+              const expectedStatement = dbStatementSerializer(operation.command, operation.args);
+              assert.strictEqual(endedSpans[0].attributes[SemanticAttributes.DB_STATEMENT], expectedStatement);
+              done();
+            });
+          });            
+        });
+      })
+    });
+
+    describe('responseHook config', () => {
+      describe('valid responseHook', () => {
+        const dataFieldName = 'redis.data';
+
+        const responseHook: RedisResponseCustomAttributeFunction = (
+          span: Span,
+          _cmdName: string,
+          _cmdArgs: string[],
+          response: unknown
+        ) => {
+          span.setAttribute(dataFieldName, new String(response).toString());
+        }
+
+        before(() => {
+          instrumentation.disable();
+          instrumentation.setConfig({ responseHook })
+          instrumentation.enable();
+        });
+
+        REDIS_OPERATIONS.forEach(operation => {
+          it(`should apply responseHook for operation ${operation.description}`, (done) => {
+            operation.method((err, reply) => {
+              assert.ifError(err);
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(endedSpans[0].attributes[dataFieldName], new String(reply).toString());
+              done();
+            });         
+          });
+        });
+      })
+
+      describe('invalid responseHook', () => {
+        const badResponseHook: RedisResponseCustomAttributeFunction = (
+          _span: Span,
+          _cmdName: string,
+          _cmdArgs: string[],
+          _response: unknown
+        ) => {
+          throw 'Some kind of error';
+        }
+
+        before(() => {
+          instrumentation.disable();
+          instrumentation.setConfig({ responseHook: badResponseHook })
+          instrumentation.enable();
+        });
+
+        REDIS_OPERATIONS.forEach(operation => {
+          it(`should not fail because of responseHook error for operation ${operation.description}`, (done) => {
+            operation.method((err, _reply) => {
+              assert.ifError(err);
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(endedSpans.length, 1);
+              done();
+            });         
+          });
+        });
+      })
+    });
+
+    describe('requireParentSpan config', () => {
+      before(() => {
+        instrumentation.disable();
+        instrumentation.setConfig({ requireParentSpan: true })
+        instrumentation.enable();
+      });
+
+      REDIS_OPERATIONS.forEach(operation => {
+        it(`should not create span without parent span for operation ${operation.description}`, (done) => {
+          operation.method((err, _) => {
+            assert.ifError(err);
+            const endedSpans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(endedSpans.length, 0);
+            done();
+          });         
+        });
+
+        it(`should create span when a parent span exists for operation ${operation.description}`, (done) => {
+          const span = tracer.startSpan('test span');
+          context.with(setSpan(context.active(), span), () => {
+            operation.method((err, _) => {
+              assert.ifError(err);
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(endedSpans.length, 1);
+              done();
+            });         
+          });
+        });
+      })
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

- Lack of data collection capabilities for redis instrumentation, when compared to the io-redis instrumentation.

## Short description of the changes

- Add `dbStatementSerializer`, `responseHook` and `requireParentSpan` configs to  `RedisInstrumentationConfig`
