### PR TITLE
feat: graphql responseHook support

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/types.ts
@@ -29,6 +29,10 @@ import { OTEL_GRAPHQL_DATA_SYMBOL, OTEL_PATCHED_SYMBOL } from './symbols';
 export const OPERATION_NOT_SUPPORTED =
   'Operation$operationName$not' + ' supported';
 
+export interface GraphQLInstrumentationExecutionResponseHook {
+  (span: api.Span, data: graphqlTypes.ExecutionResult): void;
+}
+
 export interface GraphQLInstrumentationConfig extends InstrumentationConfig {
   /**
    * When set to true it will not remove attributes values from schema source.
@@ -53,6 +57,14 @@ export interface GraphQLInstrumentationConfig extends InstrumentationConfig {
    * @default false
    */
   mergeItems?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned from "execute" GraphQL actions.
+   *
+   * @default undefined
+   */
+  responseHook?: GraphQLInstrumentationExecutionResponseHook;
 }
 
 /**

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -20,7 +20,9 @@ import {
   ReadableSpan,
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
+import { Span } from '@opentelemetry/api';
 import * as assert from 'assert';
+import type * as graphqlTypes from 'graphql';
 import { GraphQLInstrumentation } from '../src';
 import { SpanNames } from '../src/enum';
 import { AttributeNames } from '../src/enums/AttributeNames';
@@ -968,6 +970,57 @@ describe('graphql', () => {
         AttributeNames.ERROR_VALIDATION_NAME
       );
       assert.ok(event.attributes!['exception.message']);
+    });
+  });
+
+  describe('when specifying a responseHook configuration', () => {
+    let spans: ReadableSpan[];
+    let graphqlResult: graphqlTypes.ExecutionResult;
+    const dataAttributeName = 'graphql_data';
+
+    afterEach(() => {
+      exporter.reset();
+      graphQLInstrumentation.disable();
+      spans = [];
+    });
+
+    describe('AND valid responseHook', () => {
+      beforeEach(async () => {
+        create({
+          responseHook: (span: Span, data: graphqlTypes.ExecutionResult) => {
+            span.setAttribute(dataAttributeName, JSON.stringify(data));
+          },
+        });
+        graphqlResult = await graphql(schema, sourceList1);
+        spans = exporter.getFinishedSpans();
+      });
+
+      it('should attach response hook data to the resulting spans', () => {
+        const querySpan = spans.find(
+          span => span.attributes['graphql.operation.name'] == 'query'
+        );
+        const instrumentationResult = querySpan?.attributes[dataAttributeName];
+        assert.deepStrictEqual(
+          instrumentationResult,
+          JSON.stringify(graphqlResult)
+        );
+      });
+    });
+
+    describe('AND invalid responseHook', () => {
+      beforeEach(async () => {
+        create({
+          responseHook: (_span: Span, _data: graphqlTypes.ExecutionResult) => {
+            throw 'some kind of failure!';
+          },
+        });
+        graphqlResult = await graphql(schema, sourceList1);
+        spans = exporter.getFinishedSpans();
+      });
+
+      it('should not do any harm when throwing an exception', () => {
+        assert.deepStrictEqual(graphqlResult.data?.books?.length, 13);
+      });
     });
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Add the ability to collect the response to a graphql query (as an optional configuration). This data can be used for monitoring purposes.

## Short description of the changes

- add `responseHook` config to the `GraphQLInstrumentationConfig`
- When provided, safely use it to collect the data from the execution result.