### PR TITLE
feat: change requireParentSpan default value to false

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-ioredis/README.md
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/README.md
@@ -52,7 +52,7 @@ IORedis instrumentation has few options available to choose from. You can set th
 | `dbStatementSerializer` | `DbStatementSerializer`                           | IORedis instrumentation will serialize db.statement using the specified function.                                 |
 | `requestHook`           | `RedisRequestCustomAttributeFunction` (function)  | Function for adding custom attributes on db request. Receives params: `span, { moduleVersion, cmdName, cmdArgs }` |
 | `responseHook`          | `RedisResponseCustomAttributeFunction` (function) | Function for adding custom attributes on db response                                                              |
-| `requireParentSpan`     | `boolean`                                         | Require parent to create ioredis span, default when unset is true                                                 |
+| `requireParentSpan`     | `boolean`                                         | Require parent to create ioredis span, default when unset is false                                                |
 
 #### Custom db.statement Serializer
 

--- a/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts
@@ -26,7 +26,7 @@ import { traceConnection, traceSendCommand } from './utils';
 import { VERSION } from './version';
 
 const DEFAULT_CONFIG: IORedisInstrumentationConfig = {
-  requireParentSpan: true,
+  requireParentSpan: false,
 };
 
 export class IORedisInstrumentation extends InstrumentationBase<

--- a/plugins/node/opentelemetry-instrumentation-ioredis/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/src/types.ts
@@ -80,6 +80,6 @@ export interface IORedisInstrumentationConfig extends InstrumentationConfig {
   /** Function for adding custom attributes on db response */
   responseHook?: RedisResponseCustomAttributeFunction;
 
-  /** Require parent to create ioredis span, default when unset is true */
+  /** Require parent to create ioredis span, default when unset is false */
   requireParentSpan?: boolean;
 }

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
@@ -627,11 +627,11 @@ describe('ioredis', () => {
         instrumentation.disable();
         instrumentation.enable();
       });
-      it('should not create child span', async () => {
+      it('should create child span', async () => {
         await client.set(testKeyName, 'data');
         const result = await client.del(testKeyName);
         assert.strictEqual(result, 1);
-        assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
+        assert.strictEqual(memoryExporter.getFinishedSpans().length, 2);
       });
     });
 
@@ -841,6 +841,7 @@ describe('ioredis', () => {
       it('should call responseHook when set in config', async () => {
         instrumentation.disable();
         const config: IORedisInstrumentationConfig = {
+          requireParentSpan: true,
           responseHook: (
             span: Span,
             cmdName: string,


### PR DESCRIPTION
## Which problem is this PR solving?

`requireParentSpan` is true by default, to keep things consistent with the redis instrumentation we change the default to false.

## Short description of the changes

Change the default config and fix the specs accordingly.
