### PR TITLE
feat: postgresql responseHook support

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
@@ -15,3 +15,7 @@
  */
 
 export * from './instrumentation';
+export {
+  PgInstrumentationConfig,
+  PgInstrumentationExecutionResponseHook,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
@@ -16,6 +16,30 @@
 
 import * as pgTypes from 'pg';
 import * as pgPoolTypes from 'pg-pool';
+import type * as api from '@opentelemetry/api';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface PgInstrumentationExecutionResponseHook {
+  (span: api.Span, data: pgTypes.QueryResult | pgTypes.QueryArrayResult): void;
+}
+
+export interface PgInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * If true, additional information about query parameters and
+   * results will be attached (as `attributes`) to spans representing
+   * database operations.
+   */
+  enhancedDatabaseReporting?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned from "query" Pg actions.
+   * Using this requires that the `enhancedDatabaseReporting` flag be set to true.
+   *
+   * @default undefined
+   */
+  responseHook?: PgInstrumentationExecutionResponseHook;
+}
 
 export type PostgresCallback = (err: Error, res: object) => unknown;
 

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { Span, SpanStatusCode, Tracer, SpanKind, diag } from '@opentelemetry/api';
+import {
+  Span,
+  SpanStatusCode,
+  Tracer,
+  SpanKind,
+  diag,
+} from '@opentelemetry/api';
 import { AttributeNames } from './enums/AttributeNames';
 import {
   SemanticAttributes,
@@ -27,9 +33,10 @@ import {
   PgClientConnectionParams,
   PgPoolCallback,
   PgPoolExtended,
+  PgInstrumentationConfig,
 } from './types';
 import * as pgTypes from 'pg';
-import { PgInstrumentation, PgInstrumentationConfig } from './';
+import { PgInstrumentation } from './';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 
 function arrayStringifyHelper(arr: Array<unknown>): string {
@@ -174,7 +181,10 @@ export function handleExecutionResult(
   ) {
     safeExecuteInTheMiddle(
       () => {
-          config.responseHook!(span, pgResult as pgTypes.QueryResult | pgTypes.QueryArrayResult);
+        config.responseHook!(
+          span,
+          pgResult as pgTypes.QueryResult | pgTypes.QueryArrayResult
+        );
       },
       err => {
         if (err) {

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Span, SpanStatusCode, Tracer, SpanKind } from '@opentelemetry/api';
+import { Span, SpanStatusCode, Tracer, SpanKind, diag } from '@opentelemetry/api';
 import { AttributeNames } from './enums/AttributeNames';
 import {
   SemanticAttributes,
@@ -30,6 +30,7 @@ import {
 } from './types';
 import * as pgTypes from 'pg';
 import { PgInstrumentation, PgInstrumentationConfig } from './';
+import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 
 function arrayStringifyHelper(arr: Array<unknown>): string {
   return '[' + arr.toString() + ']';
@@ -161,7 +162,32 @@ export function handleInvalidQuery(
   return result;
 }
 
+export function handleExecutionResult(
+  config: PgInstrumentationConfig,
+  span: Span,
+  pgResult: pgTypes.QueryResult | pgTypes.QueryArrayResult | unknown
+) {
+  if (
+    config.enhancedDatabaseReporting &&
+    config.responseHook !== undefined &&
+    pgResult !== undefined
+  ) {
+    safeExecuteInTheMiddle(
+      () => {
+          config.responseHook!(span, pgResult as pgTypes.QueryResult | pgTypes.QueryArrayResult);
+      },
+      err => {
+        if (err) {
+          diag.error('Error running response hook', err);
+        }
+      },
+      true
+    );
+  }
+}
+
 export function patchCallback(
+  instrumentationConfig: PgInstrumentationConfig,
   span: Span,
   cb: PostgresCallback
 ): PostgresCallback {
@@ -176,7 +202,10 @@ export function patchCallback(
         code: SpanStatusCode.ERROR,
         message: err.message,
       });
+    } else {
+      handleExecutionResult(instrumentationConfig, span, res);
     }
+
     span.end();
     cb.call(this, err, res);
   };

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -25,6 +25,7 @@ import {
 } from '@opentelemetry/api';
 import { BasicTracerProvider } from '@opentelemetry/tracing';
 import { PgInstrumentation } from '../src';
+import { PgInstrumentationConfig } from '../src/types';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/test-utils';
 import {
@@ -33,7 +34,6 @@ import {
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import * as pg from 'pg';
-import * as pgTypes from 'pg';
 import * as pgPool from 'pg-pool';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { TimedEvent } from './types';
@@ -96,6 +96,11 @@ const runCallbackTest = (
 };
 
 describe('pg-pool@2.x', () => {
+  function create(config: PgInstrumentationConfig = {}) {
+    instrumentation.setConfig(config);
+    instrumentation.enable();
+  }
+
   let pool: pgPool<pg.Client>;
   let contextManager: AsyncHooksContextManager;
   let instrumentation: PgInstrumentation;
@@ -116,15 +121,7 @@ describe('pg-pool@2.x', () => {
     if (testPostgresLocally) {
       testUtils.startDocker('postgres');
     }
-  });
 
-  after(() => {
-    if (testPostgresLocally) {
-      testUtils.cleanUpDocker('postgres');
-    }
-  });
-
-  beforeEach(() => {
     instrumentation = new PgInstrumentation();
 
     contextManager = new AsyncHooksContextManager().enable();
@@ -133,18 +130,26 @@ describe('pg-pool@2.x', () => {
 
     const pgPool = require('pg-pool');
     pool = new pgPool(CONFIG);
-
-    contextManager = new AsyncHooksContextManager().enable();
-    context.setGlobalContextManager(contextManager);
   });
 
-  afterEach((done) => {
-    memoryExporter.reset();
-    context.disable();
+  after(done => {
+    if (testPostgresLocally) {
+      testUtils.cleanUpDocker('postgres');
+    }
 
     pool.end(() => {
       done();
     });
+  });
+
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+
+  afterEach(() => {
+    memoryExporter.reset();
+    context.disable();
   });
 
   it('should return an instrumentation', () => {
@@ -298,32 +303,29 @@ describe('pg-pool@2.x', () => {
 
       describe('AND valid responseHook', () => {
         beforeEach(async () => {
-          instrumentation.disable();
-          instrumentation = new PgInstrumentation({
+          const config: PgInstrumentationConfig = {
             enhancedDatabaseReporting: true,
-            responseHook: (span: Span, data: pgTypes.QueryResult | pgTypes.QueryArrayResult) => {
-              span.setAttribute(dataAttributeName, JSON.stringify({
-                "rowCount": data.rowCount,              
-              }));
-            }
-          });
-  
-          contextManager = new AsyncHooksContextManager().enable();
-          context.setGlobalContextManager(contextManager);
-          instrumentation.setTracerProvider(provider);
-          instrumentation.enable();
-          const pgPool = require('pg-pool');
-          pool = new pgPool(CONFIG);
+            responseHook: (
+              span: Span,
+              data: pg.QueryResult | pg.QueryArrayResult
+            ) =>
+              span.setAttribute(
+                dataAttributeName,
+                JSON.stringify({ rowCount: data.rowCount })
+              ),
+          };
+
+          create(config);
         });
-  
-        it('should attach response hook data to resulting spans for query with callback ', done => {  
+
+        it('should attach response hook data to resulting spans for query with callback ', done => {
           const pgPoolattributes = {
             ...DEFAULT_PGPOOL_ATTRIBUTES,
           };
           const pgAttributes = {
             ...DEFAULT_PG_ATTRIBUTES,
             [SemanticAttributes.DB_STATEMENT]: query,
-            [dataAttributeName]: '{\"rowCount\":1}'
+            [dataAttributeName]: '{"rowCount":1}',
           };
           const parentSpan = provider
             .getTracer('test-pg-pool')
@@ -341,12 +343,22 @@ describe('pg-pool@2.x', () => {
                 2,
                 0
               );
-              runCallbackTest(parentSpan, pgAttributes, events, unsetStatus, 2, 1);
+              runCallbackTest(
+                parentSpan,
+                pgAttributes,
+                events,
+                unsetStatus,
+                2,
+                1
+              );
               done();
             });
-            assert.strictEqual(resNoPromise, undefined, 'No promise is returned');
+            assert.strictEqual(
+              resNoPromise,
+              undefined,
+              'No promise is returned'
+            );
           });
-          
         });
 
         it('should attach response hook data to resulting spans for query returning a Promise', async () => {
@@ -356,44 +368,40 @@ describe('pg-pool@2.x', () => {
           const pgAttributes = {
             ...DEFAULT_PG_ATTRIBUTES,
             [SemanticAttributes.DB_STATEMENT]: query,
-            [dataAttributeName]: '{\"rowCount\":1}'
+            [dataAttributeName]: '{"rowCount":1}',
           };
-          const span = provider.getTracer('test-pg-pool').startSpan('test span');
+          const span = provider
+            .getTracer('test-pg-pool')
+            .startSpan('test span');
           await context.with(setSpan(context.active(), span), async () => {
             const result = await pool.query(query);
             runCallbackTest(span, pgPoolattributes, events, unsetStatus, 2, 0);
             runCallbackTest(span, pgAttributes, events, unsetStatus, 2, 1);
             assert.ok(result, 'pool.query() returns a promise');
           });
-
         });
       });
 
       describe('AND invalid responseHook', () => {
         beforeEach(async () => {
-          instrumentation.disable();
-          instrumentation = new PgInstrumentation({
+          create({
             enhancedDatabaseReporting: true,
-            responseHook: (span: Span, data: pgTypes.QueryResult | pgTypes.QueryArrayResult) => {
+            responseHook: (
+              span: Span,
+              data: pg.QueryResult | pg.QueryArrayResult
+            ) => {
               throw 'some kind of failure!';
-            }
+            },
           });
-  
-          contextManager = new AsyncHooksContextManager().enable();
-          context.setGlobalContextManager(contextManager);
-          instrumentation.setTracerProvider(provider);
-          instrumentation.enable();
-          const pgPool = require('pg-pool');
-          pool = new pgPool(CONFIG);
         });
 
-        it('should not do any harm when throwing an exception', done => {          
+        it('should not do any harm when throwing an exception', done => {
           const pgPoolattributes = {
             ...DEFAULT_PGPOOL_ATTRIBUTES,
           };
           const pgAttributes = {
             ...DEFAULT_PG_ATTRIBUTES,
-            [SemanticAttributes.DB_STATEMENT]: query
+            [SemanticAttributes.DB_STATEMENT]: query,
           };
           const parentSpan = provider
             .getTracer('test-pg-pool')
@@ -413,16 +421,24 @@ describe('pg-pool@2.x', () => {
                 2,
                 0
               );
-              runCallbackTest(parentSpan, pgAttributes, events, unsetStatus, 2, 1);
+              runCallbackTest(
+                parentSpan,
+                pgAttributes,
+                events,
+                unsetStatus,
+                2,
+                1
+              );
               done();
             });
-            assert.strictEqual(resNoPromise, undefined, 'No promise is returned');
+            assert.strictEqual(
+              resNoPromise,
+              undefined,
+              'No promise is returned'
+            );
           });
-
         });
       });
     });
-
-
   });
 });

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -24,8 +24,7 @@ import {
   setSpan,
 } from '@opentelemetry/api';
 import { BasicTracerProvider } from '@opentelemetry/tracing';
-import { PgInstrumentation } from '../src';
-import { PgInstrumentationConfig } from '../src/types';
+import { PgInstrumentation, PgInstrumentationConfig } from '../src';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/test-utils';
 import {
@@ -302,6 +301,15 @@ describe('pg-pool@2.x', () => {
       const events: TimedEvent[] = [];
 
       describe('AND valid responseHook', () => {
+        const pgPoolattributes = {
+          ...DEFAULT_PGPOOL_ATTRIBUTES,
+        };
+        const pgAttributes = {
+          ...DEFAULT_PG_ATTRIBUTES,
+          [SemanticAttributes.DB_STATEMENT]: query,
+          [dataAttributeName]: '{"rowCount":1}',
+        };
+
         beforeEach(async () => {
           const config: PgInstrumentationConfig = {
             enhancedDatabaseReporting: true,
@@ -319,14 +327,6 @@ describe('pg-pool@2.x', () => {
         });
 
         it('should attach response hook data to resulting spans for query with callback ', done => {
-          const pgPoolattributes = {
-            ...DEFAULT_PGPOOL_ATTRIBUTES,
-          };
-          const pgAttributes = {
-            ...DEFAULT_PG_ATTRIBUTES,
-            [SemanticAttributes.DB_STATEMENT]: query,
-            [dataAttributeName]: '{"rowCount":1}',
-          };
           const parentSpan = provider
             .getTracer('test-pg-pool')
             .startSpan('test span');
@@ -362,14 +362,6 @@ describe('pg-pool@2.x', () => {
         });
 
         it('should attach response hook data to resulting spans for query returning a Promise', async () => {
-          const pgPoolattributes = {
-            ...DEFAULT_PGPOOL_ATTRIBUTES,
-          };
-          const pgAttributes = {
-            ...DEFAULT_PG_ATTRIBUTES,
-            [SemanticAttributes.DB_STATEMENT]: query,
-            [dataAttributeName]: '{"rowCount":1}',
-          };
           const span = provider
             .getTracer('test-pg-pool')
             .startSpan('test span');
@@ -383,6 +375,14 @@ describe('pg-pool@2.x', () => {
       });
 
       describe('AND invalid responseHook', () => {
+        const pgPoolattributes = {
+          ...DEFAULT_PGPOOL_ATTRIBUTES,
+        };
+        const pgAttributes = {
+          ...DEFAULT_PG_ATTRIBUTES,
+          [SemanticAttributes.DB_STATEMENT]: query,
+        };
+
         beforeEach(async () => {
           create({
             enhancedDatabaseReporting: true,
@@ -396,13 +396,6 @@ describe('pg-pool@2.x', () => {
         });
 
         it('should not do any harm when throwing an exception', done => {
-          const pgPoolattributes = {
-            ...DEFAULT_PGPOOL_ATTRIBUTES,
-          };
-          const pgAttributes = {
-            ...DEFAULT_PG_ATTRIBUTES,
-            [SemanticAttributes.DB_STATEMENT]: query,
-          };
           const parentSpan = provider
             .getTracer('test-pg-pool')
             .startSpan('test span');


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

* Add the ability to collect the response to a pg query (as an optional configuration). This data can be used for monitoring purposes.

## Short description of the changes

* add responseHook config to PgInstrumentationConfig
* When provided, safely use it to collect the data from the execution result
