### PR TITLE
feat(aws-lambda): added customEventContextHandler config option

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/README.md
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/README.md
@@ -47,6 +47,7 @@ In your Lambda function configuration, add or update the `NODE_OPTIONS` environm
 | `requestHook` | `RequestHook` (function) | Hook for adding custom attributes before lambda starts handling the request. Receives params: `span, { event, context }` |
 | `responseHook` | `ResponseHook` (function) | Hook for adding custom attributes before lambda returns the response. Receives params: `span, { err?, res? } ` |
 | `disableAwsContextPropagation` | `boolean` | By default, this instrumentation will try to read the context from the `_X_AMZN_TRACE_ID` environment variable set by Lambda, set this to `true` to disable this behavior |
+| `eventContextExtractor` | `EventContextExtractor` (function) | Function for providing custom context extractor in order to support different event types that are handled by AWS Lambda (e.g., SQS, CloudWatch, Kinesis, API Gateway). Applied only when `disableAwsContextPropagation` is set to `true`. Receives params: `event` |
 
 ### Hooks Usage Example
 

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Span } from '@opentelemetry/api';
+import { Span, Context as OtelContext } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { Handler, Context } from 'aws-lambda';
 
@@ -33,8 +33,10 @@ export type ResponseHook = (
   }
 ) => void;
 
+export type EventContextExtractor = (event: any) => OtelContext;
 export interface AwsLambdaInstrumentationConfig extends InstrumentationConfig {
   requestHook?: RequestHook;
   responseHook?: ResponseHook;
   disableAwsContextPropagation?: boolean;
+  eventContextExtractor?: EventContextExtractor;
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Today, Lambda instrumentation supports trace propagation only for X-Ray or HTTP headers. This enhancement allows to add a custom configuration for extracting the context from incoming events to the Lambda function. This will allow the instrumentation to support more event types, such as SQS, CloudWatch or Kinesis.

## Short description of the changes

- Added `eventContextExtractor` config option to allow custom handling of events which carry the context in different ways. If not provided, a default context extractor is used and tries to pull the context from the HTTP headers - same as the behavior today.
