### PR TITLE
fix(mongo): added missing exported types

### DIFF
--- a/metapackages/auto-instrumentations-node/README.md
+++ b/metapackages/auto-instrumentations-node/README.md
@@ -5,6 +5,8 @@
 [![devDependencies][devDependencies-image]][devDependencies-url]
 [![Apache License][license-image]][license-url]
 
+This module provides a simple way to initialize multiple Node instrumentations.
+
 ## Installation
 
 ```bash
@@ -12,19 +14,25 @@ npm install --save @opentelemetry/auto-instrumentations-node
 ```
 
 ## Usage
+OpenTelemetry Meta Packages for Node automatically loads instrumentations for Node builtin modules and common packages.
+
+Custom configuration for each of the instrumentations can be passed to the function, by providing an object with the name of the instrumentation as a key, and its configuration as the value.
 
 ```javascript
 const { NodeTracerProvider } = require('@opentelemetry/node');
 const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
 const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector');
+const { Resource } = require('@opentelemetry/resources');
+const { ResourceAttributes } = require('@opentelemetry/semantic-conventions');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
-const exporter = new CollectorTraceExporter({
-  serviceName: 'auto-instrumentations-node',
+const exporter = new CollectorTraceExporter();
+const provider = new NodeTracerProvider({
+  resource: new Resource({
+    [ResourceAttributes.SERVICE_NAME]: 'basic-service',
+  }),
 });
-
-const provider = new NodeTracerProvider();
 provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 provider.register();
 
@@ -32,8 +40,8 @@ registerInstrumentations({
   instrumentations: [
     getNodeAutoInstrumentations({
       // load custom configuration for http instrumentation
-      "@opentelemetry/instrumentation-http": {
-        applyCustomAttributesOnSpan: (span)=> {
+      '@opentelemetry/instrumentation-http': {
+        applyCustomAttributesOnSpan: (span) => {
           span.setAttribute('foo2', 'bar2');
         },
       },
@@ -42,6 +50,19 @@ registerInstrumentations({
 });
 
 ```
+## Supported instrumentations
+
+- [@opentelemetry/instrumentation-dns](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns)
+- [@opentelemetry/instrumentation-http](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation-http)
+- [@opentelemetry/instrumentation-grpc](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation-grpc)
+- [@opentelemetry/instrumentation-express](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express)
+- [@opentelemetry/instrumentation-koa](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa)
+- [@opentelemetry/instrumentation-graphql](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql)
+- [@opentelemetry/instrumentation-ioredis](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-ioredis)
+- [@opentelemetry/instrumentation-redis](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis)
+- [@opentelemetry/instrumentation-pg](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pg)
+- [@opentelemetry/instrumentation-mongodb](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb)
+- [@opentelemetry/instrumentation-mysql](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql)
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
@@ -15,4 +15,8 @@
  */
 
 export * from './instrumentation';
-export { MongoDBInstrumentationConfig } from './types';
+export {
+  MongoDBInstrumentationConfig,
+  MongoDBInstrumentationExecutionResponseHook,
+  MongoResponseHookInformation,
+} from './types';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- New types were introduced in this https://github.com/open-telemetry/opentelemetry-js-contrib/pull/533 but were not exported as part of the plugin. This PR exposes them on `index.ts`

## Short description of the changes

- Added the new types `MongoDBInstrumentationExecutionResponseHook` and `MongoResponseHookInformation` to the export clause on `index.ts`
