### PR TITLE
feat: collect mongodb insert statements

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -153,12 +153,15 @@ export class MongoDBInstrumentation extends InstrumentationBase<
             kind: SpanKind.CLIENT,
           }
         );
+        const collectCommandPayload =
+          operationName !== 'insert' ||
+          !!instrumentation._config.collectInsertPayload;
         instrumentation._populateAttributes(
           span,
           ns,
           server,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          operationName !== 'insert' ? (ops[0] as any) : undefined
+          collectCommandPayload ? (ops[0] as any) : undefined
         );
         const patchedCallback = instrumentation._patchEnd(span, resultHandler);
         // handle when options is the callback to send the correct number of args

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
@@ -36,6 +36,13 @@ export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
    * @default undefined
    */
   responseHook?: MongoDBInstrumentationExecutionResponseHook;
+
+  /**
+   * If true, the payloads that are inserted to the DB will be collected.
+   *
+   * @default false
+   */
+  collectInsertPayload?: boolean;
 }
 
 export type Func<T> = (...args: unknown[]) => T;

--- a/plugins/node/opentelemetry-instrumentation-mongodb/test/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/test/utils.ts
@@ -86,9 +86,9 @@ export function assertSpans(
   assert.strictEqual(mongoSpan.status.code, SpanStatusCode.UNSET);
 
   if (isEnhancedDatabaseReportingEnabled) {
-    const dbStatement = mongoSpan.attributes[
-      SemanticAttributes.DB_STATEMENT
-    ] as any;
+    const dbStatement = JSON.parse(
+      mongoSpan.attributes[SemanticAttributes.DB_STATEMENT] as string
+    );
     for (const key in dbStatement) {
       assert.notStrictEqual(dbStatement[key], '?');
     }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The payload for insert operations is currently explicitly excluded from being collected. It is relevant to be able to collect it for monitoring, observability, security and many other use cases.

## Short description of the changes

- Add a flag (disabled by default) that allows collecting the insert payload.
